### PR TITLE
Pin API Gateway module version to 3.x branch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "api_gateway" {
   source = "terraform-aws-modules/apigateway-v2/aws"
+  version = "~> 3.1"
 
   name          = "manual_scaler-api-gw"
   description   = "My awesome HTTP API Gateway"


### PR DESCRIPTION
## What

Pinned the API Gateway module to version 3.x, so that it doesn't require AWS provider version 5.x.

## Why

No version was specified, always picking latest module version, this broke some older configs.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
